### PR TITLE
Attempt fix autograding json

### DIFF
--- a/.github/classroom/autograding.json
+++ b/.github/classroom/autograding.json
@@ -3,7 +3,7 @@
     {
       "name": "TEST INPUT/OUTPUT",
       "setup": "sudo apt install g++",
-      "run": "g++ -o output try.cpp",
+      "run": "g++ -o output try.cpp && ./output" ,
       "input": "",
       "output": "0",
       "comparison": "exact",


### PR DESCRIPTION
For merely setting up a simple repo like this, I don't think you need a `.yml` file. At least the [official docs](https://classroom.github.com/help/adding-tests-for-auto-grading) don't mention it.

The command in "run" was not running anything, so I have fixed that. It may still fail because of a mismatch in expected vs actual but that will be trivial to fix.

----

**PS** As far as i can see, you can not set up "autograding" with MS-Unit-Test-Suite. The ideology here is totally different from the normal workflow setup. But if you still need to make those work, you can do so using github actions.

@Maleehak 